### PR TITLE
Thermistor initialization in main.cpp

### DIFF
--- a/firmware/lib/ThermistorProbe/Thermistor10k.cpp
+++ b/firmware/lib/ThermistorProbe/Thermistor10k.cpp
@@ -8,10 +8,9 @@
 /**
  * @param pin - Arduino Due pin
  */
-Thermistor10k::Thermistor10k(uint32_t pin, double seriesResistor)
+Thermistor10k::Thermistor10k(uint32_t pin)
 {
     this->thermistorPin = pin;
-    this->seriesResistorVal = seriesResistor; // measure actual resistance of the 10 kOhm series resistor
 }
 /**
  * Obtains analog thermistor reading and converts it to temperature in Celsius

--- a/firmware/lib/ThermistorProbe/Thermistor10k.h
+++ b/firmware/lib/ThermistorProbe/Thermistor10k.h
@@ -13,7 +13,7 @@ class Thermistor10k
          * Constructor to create a new thermistor object.
          * @param pin - Arduino Due pin
          */
-        Thermistor10k(uint32_t pin, double seriesResistor);
+        Thermistor10k(uint32_t pin);
 
         /**
          * Obtains an analog thermistor reading and converts it to temperature in Celsius
@@ -33,9 +33,9 @@ class Thermistor10k
         static constexpr double vRef = 3.3;
         static constexpr double c1 = 0.001127354682, c2 = 0.0002343978227, c3 = 0.00000008674847738; //Steinhart-hart equation constants
         static constexpr double kelvin_to_celsius = 273.15;
+        static constexpr double seriesResistorVal = 10000.0; //10k precision resistor
 
         uint32_t thermistorPin;
-        double seriesResistorVal;
 
         double convertToTemp(int vLevel);
 };

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -27,6 +27,12 @@ void setup()
 {
     // put your setup code here, to run once:
     pinMode(LED_BUILTIN, OUTPUT);
+    // thermistor pin configurations
+    pinMode(thermistor1Pin, INPUT);
+    pinMode(thermistor2Pin, INPUT);
+    pinMode(thermistor3Pin, INPUT);
+    pinMode(thermistor4Pin, INPUT);
+    pinMode(thermistor5Pin, INPUT);
 
     DEBUG_INIT;
     serial_device.ser_connect(COMM_BAUD_RATE);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,11 +9,19 @@
 #include "Axis.h"
 #include "Movement.h"
 #include "Kinematics.h"
+#include "Thermistor10k.h"
 
 #define COMM_BAUD_RATE 115200
 
 ArduinoSerialDevice serial_device(Serial);
 TestStandCommController comm(serial_device);
+
+//will migrate pin assignment to separate file
+static const int thermistor1Pin = A0; 
+static const int thermistor2Pin = A1; 
+static const int thermistor3Pin = A2; 
+static const int thermistor4Pin = A3;
+static const int thermistor5Pin = A4;
 
 void setup()
 {
@@ -25,6 +33,14 @@ void setup()
 
     setup_axis(&axis_x_config, &axis_x);
     setup_axis(&axis_y_config, &axis_y);
+
+    analogReadResolution(12); //enable 12 bit resolution mode in Arduino Due. Default is 10 bit.
+    Thermistor10k thermistor_ambient(thermistor1Pin);
+    Thermistor10k thermistor_motor1(thermistor2Pin);
+    Thermistor10k thermistor_mpmt(thermistor3Pin);
+    Thermistor10k thermistor_motor2(thermistor4Pin);
+    Thermistor10k thermistor_optical_box(thermistor5Pin);  
+    //example usage: double temp1 = thermistor_ambient.readTemperature(); 
 }
 
 void handle_home()


### PR DESCRIPTION
* Initialized 5 thermistor objects in `main.cpp` for temperature readings for ambient, motor1, mPMT, motor2, and optical box. 
* Modified `ThermistorProbe` constructor to have `seriesResistorVal` to be `static constexpr double`. Previously, we needed to measure each resistor to obtain precise calibration. Now with precision resistors (10k ± 0.1%) variation in resistance is no longer a significant contributing factor to temperature accuracy.