### PR TITLE
Large code restructuring for cleanup, top-level architecture and serial reliability

### DIFF
--- a/MidasFrontend/feArduino.cxx
+++ b/MidasFrontend/feArduino.cxx
@@ -309,6 +309,14 @@ INT frontend_init()
 
   device.set_device_file(argv[1]);
   if (!device.ser_connect(BAUD_RATE)) return FE_ERR_HW;
+  
+  printf("Waiting for Arduino...");
+  while (!(comm.check_for_message() && comm.received_message().id == MSG_ID_PING)) {
+    // Wait for ping
+  }
+  // There might be more ping messages sitting in the buffer, so flush them all out
+  device.ser_flush();
+  printf("Connected!\n");
 
   // setup connection to ODB (online database)
   int status = cm_get_experiment_database(&hDB, NULL);

--- a/firmware/lib/ArduinoSerialDevice/src/ArduinoSerialDevice.cxx
+++ b/firmware/lib/ArduinoSerialDevice/src/ArduinoSerialDevice.cxx
@@ -11,6 +11,17 @@ bool ArduinoSerialDevice::ser_connect(uint32_t baud_rate)
     return true;
 }
 
+void ArduinoSerialDevice::ser_flush()
+{
+    // Wait for 10 ms for last bits of data
+    delay(10);
+    uint32_t avail = this->device.available();
+    while (avail > 0) {
+        this->device.read();
+        avail--;
+    }
+}
+
 uint32_t ArduinoSerialDevice::ser_available()
 {
     return this->device.available();

--- a/firmware/lib/ArduinoSerialDevice/src/ArduinoSerialDevice.h
+++ b/firmware/lib/ArduinoSerialDevice/src/ArduinoSerialDevice.h
@@ -13,6 +13,7 @@ class ArduinoSerialDevice: public SerialDevice
         ArduinoSerialDevice(HardwareSerial& device);
         
         bool ser_connect(uint32_t baud_rate);
+        void ser_flush();
         uint32_t ser_available();
         uint8_t ser_read();
         bool ser_write(uint8_t *data, uint32_t length);

--- a/firmware/lib/Debug/Debug.h
+++ b/firmware/lib/Debug/Debug.h
@@ -1,7 +1,7 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-// #define DEBUG
+#define DEBUG
 
 #ifdef DEBUG
 

--- a/firmware/lib/TestStandCommController/src/TestStandCommController.cxx
+++ b/firmware/lib/TestStandCommController/src/TestStandCommController.cxx
@@ -8,6 +8,11 @@ TestStandCommController::TestStandCommController(SerialDevice& device) : TestSta
     // Nothing else to do
 }
 
+bool TestStandCommController::ping()
+{
+    return this->send_basic_msg(MSG_ID_PING);
+}
+
 bool TestStandCommController::log(LogLevel log_level, const char *fmt, ...)
 {
     send_buf[0] = (uint8_t)log_level;

--- a/firmware/lib/TestStandCommController/src/TestStandCommController.h
+++ b/firmware/lib/TestStandCommController/src/TestStandCommController.h
@@ -10,6 +10,7 @@ class TestStandCommController : public TestStandComm
     public:
         TestStandCommController(SerialDevice& device);
 
+        bool ping();
         bool log(LogLevel log_level, const char *fmt, ...);
         bool status(Status status);
         bool data(uint8_t *data, uint8_t length);

--- a/firmware/src/mPMTTestStand.cpp
+++ b/firmware/src/mPMTTestStand.cpp
@@ -1,0 +1,100 @@
+#include "mPMTTestStand.h"
+
+#include "Axis.h"
+#include "Movement.h"
+
+#include "Debug.h"
+#include "macros.h"
+
+mPMTTestStand::mPMTTestStand(const mPMTTestStandIO& io) :
+    io(io),
+    comm_dev(io.serial_comm),
+    comm(this->comm_dev),
+    thermistor_ambient(io.pin_therm_amb),
+    thermistor_motor1(io.pin_therm_motor1),
+    thermistor_mpmt(io.pin_therm_mpmt),
+    thermistor_motor2(io.pin_therm_motor2),
+    thermistor_optical(io.pin_therm_optical)
+{
+    // Nothing else to do
+};
+
+void mPMTTestStand::setup()
+{
+    DEBUG_PRINTLN("mPMT Test Stand");
+
+    // Thermistor pin configuration
+    analogReadResolution(12); // enable 12 bit resolution mode in Arduino Due. Default is 10 bit.
+    pinMode(this->io.pin_therm_amb,     INPUT);
+    pinMode(this->io.pin_therm_motor1,  INPUT);
+    pinMode(this->io.pin_therm_mpmt,    INPUT);
+    pinMode(this->io.pin_therm_motor2,  INPUT);
+    pinMode(this->io.pin_therm_optical, INPUT);
+
+    // Connect serial communications
+    this->comm_dev.ser_connect(this->io.serial_comm_baud_rate);
+
+    // Setup gantry axis control
+    setup_axis(&axis_x_config, &axis_x);
+    setup_axis(&axis_y_config, &axis_y);
+
+    // Wait until we can successfully ping the host
+    while (!(this->comm.ping())) {
+        delay(100);
+        DEBUG_PRINTLN("Waiting for host...");
+    }
+    DEBUG_PRINTLN("Host connected!");
+};
+
+void mPMTTestStand::handle_home()
+{
+    
+};
+
+void mPMTTestStand::handle_move()
+{
+    // Process command arguments
+    uint32_t accel, hold_vel, dist;
+    uint8_t axis, dir;
+
+    uint8_t *data = this->comm.received_message().data;
+
+    accel    = NTOHL(data);
+    hold_vel = NTOHL(data + 4);
+    dist     = NTOHL(data + 8);
+    axis     = data[12];
+    dir      = data[13];
+
+    // Generate a velocity profile for the correct axis
+    Axis *axis_ptr = (axis == AXIS_X ? &axis_x : &axis_y);
+    VelProfile profile;
+    if (generate_vel_profile(accel, axis_ptr->vel_min, hold_vel, dist, &profile)) {
+        // Start the movement if the velocity profile is valid
+        axis_trapezoidal_move_rel(axis_ptr, profile.counts_accel, profile.counts_hold, profile.counts_decel, (Direction)dir);
+    }
+    
+    // TODO delete this log message:
+    this->comm.log(LL_INFO, "cts_a = %d, cts_h = %d, dist = %d, axis = %c, dir = %s",
+        profile.counts_accel,
+        profile.counts_hold,
+        dist,
+        (axis == AXIS_X ? 'x' : 'y'),
+        (dir == DIR_POSITIVE ? "pos" : "neg"));
+};
+
+void mPMTTestStand::execute()
+{
+    // Check for any messages
+    if (this->comm.check_for_message()) {
+        switch (this->comm.received_message().id) {
+            case MSG_ID_HOME:
+                handle_home();
+                break;
+            case MSG_ID_MOVE:
+                handle_move();
+                break;
+            default:
+                break;
+        }
+    }
+};

--- a/firmware/src/mPMTTestStand.h
+++ b/firmware/src/mPMTTestStand.h
@@ -1,0 +1,63 @@
+#ifndef MPMT_TEST_STAND_H
+#define MPMT_TEST_STAND_H
+
+#include <Arduino.h>
+
+#include "ArduinoSerialDevice.h"
+#include "TestStandCommController.h"
+#include "Thermistor10k.h"
+
+typedef struct {
+    // Serial Devices
+    UARTClass& serial_comm;
+    uint32_t serial_comm_baud_rate;
+    // Thermistor Pins
+    uint8_t pin_therm_amb;
+    uint8_t pin_therm_motor1;
+    uint8_t pin_therm_mpmt;
+    uint8_t pin_therm_motor2;
+    uint8_t pin_therm_optical;
+    // Gantry X-Axis Pins
+    uint8_t pin_motor_x_step;
+    uint8_t pin_motor_x_dir;
+    uint8_t pin_motor_x_enc_a;
+    uint8_t pin_motor_x_enc_b;
+    uint8_t pin_motor_x_ls_home;
+    uint8_t pin_motor_x_ls_far;
+    // Gantry Y-Axis Pins
+    uint8_t pin_motor_y_step;
+    uint8_t pin_motor_y_dir;
+    uint8_t pin_motor_y_enc_a;
+    uint8_t pin_motor_y_enc_b;
+    uint8_t pin_motor_y_ls_home;
+    uint8_t pin_motor_y_ls_far;
+} mPMTTestStandIO;
+
+typedef enum {
+    IDLE,
+    HOMING,
+    MOVING
+} SystemState;
+
+class mPMTTestStand
+{
+    private:
+        const mPMTTestStandIO& io;
+        ArduinoSerialDevice comm_dev;
+        TestStandCommController comm;
+        Thermistor10k thermistor_ambient;
+        Thermistor10k thermistor_motor1;
+        Thermistor10k thermistor_mpmt;
+        Thermistor10k thermistor_motor2;
+        Thermistor10k thermistor_optical;
+        
+        void handle_home();
+        void handle_move();
+
+    public:
+        mPMTTestStand(const mPMTTestStandIO& io);
+        void setup();
+        void execute();
+};
+
+#endif // CMD_HANDLER_H

--- a/shared/TestStandComm/Messages.h
+++ b/shared/TestStandComm/Messages.h
@@ -17,13 +17,14 @@
 #define MSG_ID_ACK         0x01
 #define MSG_ID_NACK        0x02
 
+#define MSG_ID_PING        0x03
+
 // PC -> Arduino Messages
-#define MSG_ID_PING        0x40
-#define MSG_ID_GET_STATUS  0x41
-#define MSG_ID_HOME        0x42
-#define MSG_ID_MOVE        0x43
-#define MSG_ID_STOP        0x44
-#define MSG_ID_GET_DATA    0x45
+#define MSG_ID_GET_STATUS  0x40
+#define MSG_ID_HOME        0x41
+#define MSG_ID_MOVE        0x42
+#define MSG_ID_STOP        0x43
+#define MSG_ID_GET_DATA    0x44
 
 // Arduino -> PC Messages
 #define MSG_ID_LOG         0x80

--- a/shared/TestStandComm/SerialDevice.h
+++ b/shared/TestStandComm/SerialDevice.h
@@ -7,6 +7,7 @@ class SerialDevice
 {
     public:
         virtual bool ser_connect(uint32_t baud_rate) = 0;
+        virtual void ser_flush() = 0;
         virtual uint32_t ser_available() = 0;
         virtual uint8_t ser_read() = 0;
         virtual bool ser_write(uint8_t *data, uint32_t length) = 0;

--- a/shared/TestStandComm/SerialTransport.cxx
+++ b/shared/TestStandComm/SerialTransport.cxx
@@ -61,8 +61,9 @@ bool SerialTransport::check_for_message(Message& msg)
                     }
                     break;
                 case MSG_SEG_END:
+                    this->reset();
                     if (byte_in == MSG_DELIM_END) {
-                        this->reset();
+                        // Stop processing serial data as soon as we've read in a full message
                         return true;
                     }
                     break;

--- a/shared_linux/LinuxSerialDevice/LinuxSerialDevice.cxx
+++ b/shared_linux/LinuxSerialDevice/LinuxSerialDevice.cxx
@@ -80,6 +80,13 @@ bool LinuxSerialDevice::ser_connect(uint32_t baud_rate)
     return true;
 }
 
+void LinuxSerialDevice::ser_flush()
+{
+    // Wait for 10 ms for last bits of data
+    usleep(10000);
+    tcflush(this->serial_port, TCIOFLUSH);
+}
+
 uint32_t LinuxSerialDevice::ser_available()
 {
     uint32_t bytes_avail;

--- a/shared_linux/LinuxSerialDevice/LinuxSerialDevice.h
+++ b/shared_linux/LinuxSerialDevice/LinuxSerialDevice.h
@@ -16,6 +16,7 @@ class LinuxSerialDevice: public SerialDevice
         void set_device_file(const char *device_file);
 
         bool ser_connect(uint32_t baud_rate);
+        void ser_flush();
         uint32_t ser_available();
         uint8_t ser_read();
         bool ser_write(uint8_t *data, uint32_t length);


### PR DESCRIPTION
- Created mPMTTestStand class and moved most of the main.cpp code into there
  - mPMTTestStand accepts a list of IO configurations (pin numbers, serial devices etc.) to setup all the other objects
  - The motor control pins are included but not currently used, will come in a future PR

- Modified the startup procedure, so the Arduino pings the host until the host responds
  - The host equivalently waits for a ping from the Arduino before sending any other commands
  - PING is now a two-way message to allow for this
  - Implemented a flush feature in the serial device libraries so that the extra ping messages can be flushed out

- Misc. serial reliability improvements
  - pending message resets even if the END byte is incorrect
  - session will not ACK an ACK and ignore it instead

- Enabled DEBUG