### PR TITLE
Improved serial communication robustness

### DIFF
--- a/firmware/lib/Comm/src/TestStandCommController.h
+++ b/firmware/lib/Comm/src/TestStandCommController.h
@@ -2,6 +2,8 @@
 #define TEST_STAND_COMM_CONTROLLER_H
 
 #include "TestStandComm.h"
+#include "TestStandMessages.h"
+#include "Gantry.h"
 
 #include "shared_defs.h"
 
@@ -21,6 +23,9 @@ class TestStandCommController : public TestStandComm
         SerialResult position(int32_t x_counts, int32_t y_counts);
         SerialResult axis_state(/*TODO*/);
         SerialResult temp(/*TODO*/);
+        SerialResult axis_result(AxisResult result);
+
+        bool recv_move(MoveMsgData *data_out);
 };
 
 #endif // TEST_STAND_COMM_CONTROLLER_H

--- a/firmware/src/mPMTTestStand.h
+++ b/firmware/src/mPMTTestStand.h
@@ -31,6 +31,7 @@ typedef struct {
 
 typedef struct {
     AxisMech axis_mech;
+    uint32_t accel;
     uint32_t vel_start;
     uint32_t vel_home_a;
     uint32_t vel_home_b;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -57,6 +57,7 @@ const mPMTTestStandConfig conf = {
             .counts_per_rev     = 500,    // For Igus gantry encoders
             .steps_per_rev      = (200*4) // 200 * microstep = 200 * 4
         },
+        .accel                  = 8000,   // acceleration for all motion [steps / s^2]
         .vel_start              = 500,    // starting velocity for all motion [steps / s]
         .vel_home_a             = 10000,  // holding velocity for homing A [steps / s]
         .vel_home_b             = 10000,  // holding velocity for homing B [steps / s]

--- a/shared/TestStandComm/Messages.h
+++ b/shared/TestStandComm/Messages.h
@@ -8,40 +8,10 @@
 #define MSG_DELIM_START         0x7B
 #define MSG_DELIM_END           0x7D
 
-/*****************************************************************************/
-/*                                MESSAGE IDS                                */
-/*****************************************************************************/
-
 #define MSG_ID_INVALID          0x00
 
 #define MSG_ID_ACK              0x01
 #define MSG_ID_NACK             0x02
-
-#define MSG_ID_PING             0x03
-
-// PC -> Arduino Messages
-#define MSG_ID_GET_STATUS       0x40
-#define MSG_ID_HOME             0x41
-#define MSG_ID_MOVE             0x42
-#define MSG_ID_STOP             0x43
-#define MSG_ID_GET_POSITION     0x44
-#define MSG_ID_GET_AXIS_STATE   0x45
-#define MSG_ID_GET_TEMP         0x46
-
-// Arduino -> PC Messages
-#define MSG_ID_LOG              0x80
-#define MSG_ID_STATUS           0x81
-#define MSG_ID_POSITION         0x82
-#define MSG_ID_AXIS_STATE       0x83
-#define MSG_ID_TEMP             0x84
-
-typedef enum {
-    LL_DEBUG,
-    LL_INFO,
-    LL_WARNING,
-    LL_ERROR,
-    LL_CRITICAL
-} LogLevel;
 
 typedef struct {
     uint8_t id;

--- a/shared/TestStandComm/SerialResult.h
+++ b/shared/TestStandComm/SerialResult.h
@@ -17,7 +17,8 @@ typedef enum {
     SERIAL_ERR_SEND_FAILED,     //!< Message failed to send
     SERIAL_ERR_NO_ACK,          //!< After sending a message, the response was not an ACK
     SERIAL_ERR_ACK_FAILED,      //!< After receiving a message, failed to send an ACK
-    SERIAL_ERR_WRONG_MSG        //!< An unexpected message was received
+    SERIAL_ERR_WRONG_MSG,       //!< An unexpected message was received
+    SERIAL_ERR_DATA_LENGTH      //!< Wrong length of data was received
 } SerialResult;
 
 #endif // SERIAL_RESULT_H

--- a/shared/TestStandComm/TestStandComm.cxx
+++ b/shared/TestStandComm/TestStandComm.cxx
@@ -42,10 +42,22 @@ SerialResult TestStandComm::check_for_message()
 
 /**
  * @brief Wrapper around @see SerialSession::recv_message(uint32_t timeout_ms)
+ * 
+ * @param expect_id     The expected ID of the message being received
+ * @param expect_length The expected data length of the message being received
+ * 
+ * @return @see SerialSession::recv_message(uint32_t timeout_ms)
+ *         SERIAL_ERR_WRONG_MSG if the received ID does not match expect_id
+ *         SERIAL_ERR_DATA_LENGTH if the received data length does not match expect_length
  */
-SerialResult TestStandComm::recv_message(uint32_t timeout_ms)
+SerialResult TestStandComm::recv_message(uint8_t expect_id, uint8_t expect_length, uint32_t timeout_ms)
 {
-    return this->session.recv_message(timeout_ms);
+    SerialResult res = this->session.recv_message(timeout_ms);
+    if (res != SERIAL_OK) return res;
+
+    if (this->received_message().id != expect_id) return SERIAL_ERR_WRONG_MSG;
+    if (this->received_message().length != expect_length) return SERIAL_ERR_DATA_LENGTH;
+    return SERIAL_OK;
 }
 
 /**

--- a/shared/TestStandComm/TestStandComm.h
+++ b/shared/TestStandComm/TestStandComm.h
@@ -33,7 +33,7 @@ class TestStandComm
         TestStandComm(SerialDevice& device);
 
         SerialResult check_for_message();
-        SerialResult recv_message(uint32_t timeout_ms);
+        SerialResult recv_message(uint8_t expect_id, uint8_t expect_length, uint32_t timeout_ms);
         Message& received_message();
 
 };

--- a/shared/TestStandMessages.h
+++ b/shared/TestStandMessages.h
@@ -1,0 +1,64 @@
+#ifndef TEST_STAND_MESSAGES_H
+#define TEST_STAND_MESSAGES_H
+
+#include "Gantry.h"
+#include <stdint.h>
+
+/*****************************************************************************/
+/*                                MESSAGE IDS                                */
+/*****************************************************************************/
+
+// Two-way Messages
+#define MSG_ID_PING             0x03
+
+// PC -> Arduino Messages
+#define MSG_ID_GET_STATUS       0x40
+#define MSG_ID_HOME             0x41
+#define MSG_ID_MOVE             0x42
+#define MSG_ID_STOP             0x43
+#define MSG_ID_GET_POSITION     0x44
+#define MSG_ID_GET_AXIS_STATE   0x45
+#define MSG_ID_GET_TEMP         0x46
+
+// Arduino -> PC Messages
+#define MSG_ID_LOG              0x80
+#define MSG_ID_STATUS           0x81
+#define MSG_ID_POSITION         0x82
+#define MSG_ID_AXIS_STATE       0x83
+#define MSG_ID_TEMP             0x84
+#define MSG_ID_AXIS_RESULT      0x85
+
+/*****************************************************************************/
+/*                                   ENUMS                                   */
+/*****************************************************************************/
+
+typedef enum {
+    LL_DEBUG,
+    LL_INFO,
+    LL_WARNING,
+    LL_ERROR,
+    LL_CRITICAL
+} LogLevel;
+
+/*****************************************************************************/
+/*                               DATA STRUCTS                                */
+/*****************************************************************************/
+
+/**
+ * NOTE: These structs are packed so that they have the same size on a 64-bit
+ *       PC as on the 32-bit Arduino Due
+ */
+
+typedef struct {
+    uint32_t vel_hold;
+    uint32_t dist_counts;
+    uint8_t axis;
+    uint8_t dir;
+} __attribute__((__packed__)) MoveMsgData;
+
+typedef struct {
+    int32_t x_counts;
+    int32_t y_counts;
+} __attribute__((__packed__)) PositionMsgData;
+
+#endif // TEST_STAND_MESSAGES_H

--- a/shared/Util/macros.h
+++ b/shared/Util/macros.h
@@ -5,34 +5,34 @@
 /* BYTE ORDER MACROS                                                          */
 /******************************************************************************/
 
-#define NTOHS(_ptr)                     \
-    (                                   \
-    ((uint16_t)(*((_ptr) + 0)) << 8)  | \
-    ((uint16_t)(*((_ptr) + 1)) << 0)    \
+#define NTOHS(_ptr)                                \
+    (                                              \
+    ((uint16_t)(*((uint8_t *)(_ptr) + 0)) << 8)  | \
+    ((uint16_t)(*((uint8_t *)(_ptr) + 1)) << 0)    \
     )
 
-#define NTOHL(_ptr)                     \
-    (                                   \
-    ((uint32_t)(*((_ptr) + 0)) << 24) | \
-    ((uint32_t)(*((_ptr) + 1)) << 16) | \
-    ((uint32_t)(*((_ptr) + 2)) << 8)  | \
-    ((uint32_t)(*((_ptr) + 3)) << 0)    \
+#define NTOHL(_ptr)                                \
+    (                                              \
+    ((uint32_t)(*((uint8_t *)(_ptr) + 0)) << 24) | \
+    ((uint32_t)(*((uint8_t *)(_ptr) + 1)) << 16) | \
+    ((uint32_t)(*((uint8_t *)(_ptr) + 2)) << 8)  | \
+    ((uint32_t)(*((uint8_t *)(_ptr) + 3)) << 0)    \
     )
 
 #define GET_BYTE(_x, _n) ((uint8_t)(((_x) >> ((_n)*8)) & 0xFF))
 
-#define HTONS(_ptr, _val)                    \
-    do {                                     \
-        (*((_ptr) + 0)) = GET_BYTE(_val, 1); \
-        (*((_ptr) + 1)) = GET_BYTE(_val, 0); \
+#define HTONS(_ptr, _val)                               \
+    do {                                                \
+        (*((uint8_t *)(_ptr) + 0)) = GET_BYTE(_val, 1); \
+        (*((uint8_t *)(_ptr) + 1)) = GET_BYTE(_val, 0); \
     } while (0)
 
-#define HTONL(_ptr, _val)                    \
-    do {                                     \
-        (*((_ptr) + 0)) = GET_BYTE(_val, 3); \
-        (*((_ptr) + 1)) = GET_BYTE(_val, 2); \
-        (*((_ptr) + 2)) = GET_BYTE(_val, 1); \
-        (*((_ptr) + 3)) = GET_BYTE(_val, 0); \
+#define HTONL(_ptr, _val)                               \
+    do {                                                \
+        (*((uint8_t *)(_ptr) + 0)) = GET_BYTE(_val, 3); \
+        (*((uint8_t *)(_ptr) + 1)) = GET_BYTE(_val, 2); \
+        (*((uint8_t *)(_ptr) + 2)) = GET_BYTE(_val, 1); \
+        (*((uint8_t *)(_ptr) + 3)) = GET_BYTE(_val, 0); \
     } while (0)
 
 #endif // MACROS_H

--- a/shared_linux/TestStandCommHost/TestStandCommHost.cxx
+++ b/shared_linux/TestStandCommHost/TestStandCommHost.cxx
@@ -1,6 +1,9 @@
 #include "TestStandCommHost.h"
 #include "Gantry.h"
+
 #include "macros.h"
+
+#include <stdio.h>
 
 TestStandCommHost::TestStandCommHost(SerialDevice& device) : TestStandComm(device)
 {
@@ -17,10 +20,8 @@ SerialResult TestStandCommHost::get_status(Status *status_out, uint32_t timeout_
     SerialResult res = this->send_basic_msg(MSG_ID_GET_STATUS);
     if (res != SERIAL_OK) return res;
 
-    res = this->recv_message(timeout_ms);
+    res = this->recv_message(MSG_ID_STATUS, 1, timeout_ms);
     if (res != SERIAL_OK) return res;
-
-    if (this->received_message().id != MSG_ID_STATUS) return SERIAL_ERR_WRONG_MSG;
 
     *status_out = (Status)((this->received_message().data)[0]);
     return SERIAL_OK;
@@ -31,22 +32,30 @@ SerialResult TestStandCommHost::home()
     return this->send_basic_msg(MSG_ID_HOME);
 }
 
-SerialResult TestStandCommHost::move(uint32_t accel, uint32_t hold_vel, uint32_t dist, AxisId axis, AxisDirection dir)
+SerialResult TestStandCommHost::move(AxisId axis, AxisDirection dir, uint32_t vel_hold, uint32_t dist_counts, AxisResult *res_out, uint32_t timeout_ms)
 {
-    // Transmit in big endian order
-    uint8_t data[14];
-    HTONL(data, accel);
-    HTONL(data + 4, hold_vel);
-    HTONL(data + 8, dist);
-    data[12] = (uint8_t)axis;
-    data[13] = (uint8_t)dir;
+    // Send move message
+    MoveMsgData data;
+    data.axis = (uint8_t)axis;
+    data.dir = (uint8_t)dir;
+    HTONL(&(data.vel_hold), vel_hold);
+    HTONL(&(data.dist_counts), dist_counts);
 
     Message msg = {
         .id = MSG_ID_MOVE,
         .length = sizeof(data),
-        .data = data
+        .data = (uint8_t *)&data
     };
-    return this->session.send_message(msg);
+    
+    SerialResult res = this->session.send_message(msg);
+    if (res != SERIAL_OK) return res;
+
+    // Get result
+    res = this->recv_message(MSG_ID_AXIS_RESULT, 1, timeout_ms);
+    if (res != SERIAL_OK) return res;
+
+    *res_out = (AxisResult)((this->received_message().data)[0]);
+    return SERIAL_OK;
 }
 
 SerialResult TestStandCommHost::stop()
@@ -54,18 +63,16 @@ SerialResult TestStandCommHost::stop()
     return this->send_basic_msg(MSG_ID_STOP);
 }
 
-SerialResult TestStandCommHost::get_position(Position *position_out, uint32_t timeout_ms)
+SerialResult TestStandCommHost::get_position(PositionMsgData *position_out, uint32_t timeout_ms)
 {
     SerialResult res = this->send_basic_msg(MSG_ID_GET_POSITION);
     if (res != SERIAL_OK) return res;
 
-    res = this->recv_message(timeout_ms);
+    res = this->recv_message(MSG_ID_POSITION, sizeof(PositionMsgData), timeout_ms);
     if (res != SERIAL_OK) return res;
 
-    if (this->received_message().id != MSG_ID_POSITION) return SERIAL_ERR_WRONG_MSG;
-
-    uint8_t *data = this->received_message().data;
-    position_out->x_counts = NTOHL(data);
-    position_out->y_counts = NTOHL(data + 4);
+    PositionMsgData *data_in = (PositionMsgData *)this->received_message().data;
+    position_out->x_counts = NTOHL(&(data_in->x_counts));
+    position_out->y_counts = NTOHL(&(data_in->y_counts));
     return SERIAL_OK;
 }

--- a/shared_linux/TestStandCommHost/TestStandCommHost.h
+++ b/shared_linux/TestStandCommHost/TestStandCommHost.h
@@ -2,14 +2,10 @@
 #define TEST_STAND_COMM_HOST_H
 
 #include "TestStandComm.h"
+#include "TestStandMessages.h"
 #include "Gantry.h"
 
 #include "shared_defs.h"
-
-typedef struct {
-    int32_t x_counts;
-    int32_t y_counts;
-} Position;
 
 /**
  * @class TestStandCommHost
@@ -24,9 +20,9 @@ class TestStandCommHost : public TestStandComm
         SerialResult ping();
         SerialResult get_status(Status *status_out, uint32_t timeout_ms);
         SerialResult home();
-        SerialResult move(uint32_t accel, uint32_t hold_vel, uint32_t dist, AxisId axis, AxisDirection dir);
+        SerialResult move(AxisId axis, AxisDirection dir, uint32_t vel_hold, uint32_t dist_counts, AxisResult *res_out, uint32_t timeout_ms);
         SerialResult stop();
-        SerialResult get_position(Position *position_out, uint32_t timeout_ms);
+        SerialResult get_position(PositionMsgData *position_out, uint32_t timeout_ms);
 };
 
 #endif // TEST_STAND_COMM_HOST_H


### PR DESCRIPTION
- Moved message id definitions into TestStandMessages.h (separate from the library Messages.h)
- Message data payloads are now specified as structs, so their size and field order is well determined
- Message IDs and data lengths are now checked in TestStandComm
- Implemented AXIS_RESULT message in response to the MOVE command so the errors can be handled on the host side
- Removed acceleration from the MOVE message (it's part of the gantry config now)
- Added explicit (uint8_t *) pointer casts to byte order macros